### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/deploy-vuestorefront-cloud.yaml
+++ b/.github/workflows/deploy-vuestorefront-cloud.yaml
@@ -12,7 +12,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v1
       - name: Build and publish docker image
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: docs-storefrontcloud-io/cloud:${{ github.sha }}
           registry: registry.storefrontcloud.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore